### PR TITLE
Use release builds in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,19 +34,19 @@ jobs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: cargo-release-${{ hashFiles('**/Cargo.lock') }}-${{ runner.os }}
 
     - name: Build
-      run: cargo build --all --locked --timings
+      run: cargo build --release --all --locked --timings
 
     - name: Test
-      run: cargo test --all --locked
+      run: cargo test --release --all --locked
 
     - name: Format
       run: cargo fmt --all -- --check
 
     - name: Clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --release --all --locked -- -D warnings
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
The resulting build artifacts should be smaller.