### PR TITLE
Simplify header sync and reorg logic

### DIFF
--- a/src/bin/bindex.rs
+++ b/src/bin/bindex.rs
@@ -183,6 +183,7 @@ fn main() -> Result<(), Error> {
     let url = format!("http://localhost:{}", default_rpc_port);
     let db_path = format!("db/{default_db_dir}");
 
+    info!("Using DB={} URL={}", db_path, url);
     let scripts: HashSet<_> = args
         .addresses
         .iter()

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,7 +1,6 @@
 use crate::index;
 
 use bitcoin::{hashes::Hash, BlockHash};
-use log::*;
 
 pub struct Chain {
     rows: Vec<index::Header>,
@@ -9,13 +8,11 @@ pub struct Chain {
 
 impl Chain {
     pub fn new(rows: Vec<index::Header>) -> Self {
-        info!("loaded {} headers", rows.len());
         let mut block_hash = bitcoin::BlockHash::all_zeros();
         for row in &rows {
             assert_eq!(row.header().prev_blockhash, block_hash);
             block_hash = row.hash();
         }
-        debug!("verified {} headers, tip={}", rows.len(), block_hash);
         Self { rows }
     }
 


### PR DESCRIPTION
Also, use binary format when fetching headers.